### PR TITLE
Handle string responses from Bamboo gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 0.1.3
+
+Handle Bamboo returning a string instead of JSON more gracefully.

--- a/lib/bamboo_id/requests/basic_request_handling.rb
+++ b/lib/bamboo_id/requests/basic_request_handling.rb
@@ -11,7 +11,13 @@ module BambooId
       private
 
       def response
-        @response ||= OpenStruct.new(self.class.post(url.to_s, body: url.params, headers: headers))
+        @response ||= OpenStruct.new(http_response)
+      rescue NoMethodError, JSON::ParserError
+        OpenStruct.new(error: 'Invalid response from Bamboo. Please try again.')
+      end
+
+      def http_response
+        @http_response ||= self.class.post(url.to_s, body: url.params, headers: headers)
       end
 
       def headers

--- a/lib/bamboo_id/version.rb
+++ b/lib/bamboo_id/version.rb
@@ -1,3 +1,3 @@
 module BambooId
-  VERSION = "0.1.2"
+  VERSION = "0.1.3"
 end

--- a/spec/lib/bamboo_id/requests/access_token_request_spec.rb
+++ b/spec/lib/bamboo_id/requests/access_token_request_spec.rb
@@ -54,6 +54,24 @@ module BambooId
           end
         end
       end
+
+      context 'when bamboo blows up and returns an error page instead of a hash' do
+        let(:response_body) do
+          'oh no i blew up and this is a string'
+        end
+
+        describe '#successful?' do
+          it 'returns false' do
+            expect(request).to_not be_successful
+          end
+        end
+
+        describe '#access_token' do
+          it 'returns nil' do
+            expect(request.access_token).to be nil
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
If Bamboo blows up and returns a string instead of JSON,
let's handle it more gracefully.