### PR TITLE
Ability to pass custom state in authentication URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Or install it yourself as:
 
 ### Configuration
 
-`Bamboo::Configuration.redirect_url` must be set.
+`BambooId::Configuration.redirect_url` must be set.
 
 The following environment variables are also required:
 - `BAMBOO_APPLICATION_KEY`
@@ -33,13 +33,20 @@ The following environment variables are also required:
 
 To get the initial authorization URL, use `BambooId::Urls::AuthUrl.new(subdomain).to_s`
 
+You can also pass an optional custom `state` attribute to this URL like this:
+
+```ruby
+state = "my_custom_state"
+BambooId::Urls::AuthUrl.new(subdomain, state).to_s
+```
+
 In the callback controller, you can use `BambooId::ApiKeyFetcher` to get an API key
 using the code passed to you like so:
 
 ```ruby
 ::BambooId::ApiKeyFetcher.new(
   code: params[:code],
-  integration: current_company.user_management_integration
+  subdomain: subdomain,
 ).fetch
 ```
 

--- a/lib/bamboo_id/urls/auth_url.rb
+++ b/lib/bamboo_id/urls/auth_url.rb
@@ -13,13 +13,14 @@ module BambooId
       include BambooUrl
       include BaseAuthUrl
 
-      def initialize(subdomain)
+      def initialize(subdomain, state = nil)
         self.subdomain = subdomain
+        self.state = state
       end
 
       private
 
-      attr_accessor :subdomain
+      attr_accessor :subdomain, :state
 
       def additional_params
         {
@@ -44,7 +45,7 @@ module BambooId
       end
 
       def state_code
-        StateCode.new(subdomain).to_s
+        state || StateCode.new(subdomain).to_s
       end
     end
   end

--- a/lib/bamboo_id/version.rb
+++ b/lib/bamboo_id/version.rb
@@ -1,3 +1,3 @@
 module BambooId
-  VERSION = "0.1.3"
+  VERSION = "0.1.4"
 end


### PR DESCRIPTION
It was required for our project to pass in a custom `state` to the authentication URL. So we have added the ability to do so. Plus made some minor corrections in the **readme.md**. Passing the custom `state` is optional and the existing behavior will be used if no custom `state` is passed.